### PR TITLE
Stop processing notifications if payment has already failed

### DIFF
--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -53,7 +53,7 @@ module Spree
         notification.processed!
         # ignore failures if the payment was already completed, or if it doesn't
         # exist
-        return if payment.nil? || payment.completed?
+        return if payment.nil? || payment.completed? || payment.failed?
         # might have to do something else on modification events,
         # namely refunds
         payment.failure!

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -88,6 +88,15 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
           from("pending").
           to("failed")
       end
+
+      context "when payment has already failed" do
+        before { payment.update(state: 'failed') }
+
+        it "does not change the payment state" do
+          expect{ subject }.to_not change{ payment.state }
+        end
+      end
+
     end
 
     shared_examples "does nothing" do

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
       end
 
       context "when payment has already failed" do
-        before { payment.update(state: 'failed') }
+        before { payment.update(state: "failed") }
 
         it "does not change the payment state" do
           expect{ subject }.to_not change{ payment.state }


### PR DESCRIPTION
*What*

Returns early if payment has already failed.

*Why*

Adyen notifications can receive multiple notifications from Adyen where success is false. So on the first occasion, from what we can see, the payment is marked as failed. Then the subsequent notifications will raise an exception because a payment can't fail subsequent times as it's already failed.